### PR TITLE
Fix Github to existing user duplication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,10 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :rememberable, :trackable, :validatable, :omniauthable, :omniauth_providers => [:github]
 
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+    where(email: auth.info.email).first_or_create do |user|
       user.email = auth.info.email
+      user.uid = auth.uid
+      user.provider = auth.provider
       user.password = Devise.friendly_token[0,20]
       user.name = auth.info.name   # assuming the user model has a name
     end


### PR DESCRIPTION
Eğer kullanıcı halihazırda var olan aynı e-posta ile Github girişi yaparsa güncellemek yerine bir tane daha kullanıcı açıyordu. Bu fix onu düzeltiyor.