### PR TITLE
#53 - Fix ui bug in user card thumbnails

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -171,6 +171,7 @@ textarea {
     background: #f5f5f5;
     padding: 10px;
     margin-bottom: 20px;
+    min-height: 223px;
   }
   .thumbnail a {
     display: inline-block;


### PR DESCRIPTION
Mobil, tablet ve web boyutlarının hepsinde user card'lar için aynı yükseklik kullanılıyor. Bu yüzden hardcoded şekilde `223px` vermek problem oluşturmuyor.