### PR TITLE
sadece slack-notifier...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .idea/
 .rspec
 vendor/bundle
+.rbenv-vars

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'humanizer', '~> 2.6.0'
 gem 'omniauth'
 gem 'omniauth-github'
 gem 'simple_form'
+gem 'slack-notifier'
 
 group :production do
   gem 'pg', '~> 0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,7 @@ GEM
     simple_form (3.4.0)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
+    slack-notifier (2.1.0)
     slop (3.6.0)
     spork (1.0.0rc4)
     spring (1.3.6)
@@ -391,6 +392,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   shoulda
   simple_form
+  slack-notifier
   spork (~> 1.0rc)
   spring
   sqlite3 (~> 1.3.8)
@@ -398,4 +400,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,4 +1,6 @@
 class CompaniesController < ApplicationController
+  after_action :send_notification, only: :create
+
   def index
     @companies = Company.published
   end
@@ -17,8 +19,14 @@ class CompaniesController < ApplicationController
     end
   end
 
+  private
+
   def company_params
     params.require(:company).permit(:title, :sector, :url, :github, :twitter, :city,
                                     :humanizer_answer, :humanizer_question_id)
+  end
+
+  def send_notification
+    Slack::Notifier.new(ENV['WEBHOOK_URL']).ping('Yeni şirket eklendi.')
   end
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,6 +1,4 @@
 class CompaniesController < ApplicationController
-  after_action :send_notification, only: :create
-
   def index
     @companies = Company.published
   end
@@ -26,7 +24,4 @@ class CompaniesController < ApplicationController
                                     :humanizer_answer, :humanizer_question_id)
   end
 
-  def send_notification
-    Slack::Notifier.new(ENV['WEBHOOK_URL']).ping('Yeni şirket eklendi.')
-  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -10,7 +10,7 @@ class Company < ActiveRecord::Base
   scope :published, -> { where(published: true) }
 
   def send_notification
-    Slack::Notifier.new(ENV['WEBHOOK_URL']).ping('Yeni şirket eklendi.')
+    Slack::Notifier.new(ENV['WEBHOOK_URL']).ping("Yeni şirket eklendi: #{Company.last.title}")
   end
 
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,4 +1,6 @@
 class Company < ActiveRecord::Base
+  after_commit :send_notification, on: :create
+
   validates :title, :sector, :city, :url, presence: true
 
   include Humanizer
@@ -6,4 +8,9 @@ class Company < ActiveRecord::Base
   require_human_on :create, unless: :bypass_humanizer
 
   scope :published, -> { where(published: true) }
+
+  def send_notification
+    Slack::Notifier.new(ENV['WEBHOOK_URL']).ping('Yeni şirket eklendi.')
+  end
+
 end


### PR DESCRIPTION
Fixes #64 

Sadece slack-notifier gem'i işimize yarayacağa benziyor. #rastgele kanalında test ettim, çalışıyor. Tek ihtiyacımız bir WEBHOOK_URL tanımlamak, onu da merge edecek arkadaşımıza gönderebilirim ya da [buradan](https://rubytr.slack.com/services/B5G9JTUFQ) oluşturabiliriz.