### PR TITLE
Active Admin DB Kurulum Hatası

### DIFF
--- a/app/admin/announcement.rb
+++ b/app/admin/announcement.rb
@@ -1,5 +1,7 @@
 def admin_collection
-  AdminUser.all.map { |a| [a.email, a.id] }
+  proc {
+    AdminUser.all.map { |a| [a.email, a.id] }
+  }
 end
 
 ActiveAdmin.register Announcement do


### PR DESCRIPTION
ActiveAdmin'in Announcement dosyasında admin_collection metodunun içinde ki ifade proc metodu içinde çalıştırılarak db setup edilememesi hatası çözüldü

resolve #82 