### PR TITLE
fix login via github

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[0, 20]
       user.name = auth.info.name
       user.github = auth.extra.raw_info.login
+      user.bypass_humanizer = true
     end
   end
 


### PR DESCRIPTION
https://github.com/rubytr/ruby-tr/blob/921035b620f603a109a6c3b9e14d25ea2ab7ead2/config/initializers/devise.rb#L238

Lokalde test ettiğim kadarıyla buradaki `ENV['GITHUB_APP_ID']` boş döndüğü için 404 e düşüyor. Ayrıca `ENV['GITHUB_APP_SECRET']` bunun da ayarlanması gerekiyor. 

Son olarak;
https://github.com/rubytr/ruby-tr/blob/921035b620f603a109a6c3b9e14d25ea2ab7ead2/app/models/user.rb#L14

Burada humanizer kütüphanesinden dolayı kullanıcı kaydı yapılamıyor ve bu pr o problemi çözüyor. Lokalde test ettiğim kadarıyla her şey düzgün çalışıyor.