### PR TITLE
Stop using Slackin in favor of native Slack invite links

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -22,7 +22,7 @@
             <% end %>
           </div>
           <div>
-          <%= link_to "https://rubytr.herokuapp.com/", target: "_blank" do %>
+          <%= link_to "https://slack.rubyturkiye.org/", target: "_blank" do %>
             <%= fa_icon "slack", text: "Slack" %>
           <% end %>
           </div>


### PR DESCRIPTION
### Açıklama

I've added the slack.rubyturkiye.org domain on Cloudflare which redirects to the invite link provided by Slack itself. This is a more sustainable solution than using Slackin, which is mostly dead by now.

### Değişiklik tipi

<!-- Lütfen uymayan tüm başlıkları siliniz. Hiç biri uymuyorsa kendiniz yazınız. -->

* URL güncelleme

### Bu PR için hangi testler yazıldı? Ve bu testlerin olası beklenen sonuçları nelerdir?

Test yazılmadı